### PR TITLE
Add Cross.toml in order to pass the NIF version to cross

### DIFF
--- a/native/qrusty/Cross.toml
+++ b/native/qrusty/Cross.toml
@@ -1,0 +1,4 @@
+[build.env]
+passthrough = [
+  "RUSTLER_NIF_VERSION"
+]


### PR DESCRIPTION
This is important because `cross` don't have access by default to the
env vars of the system.

This is related to https://github.com/philss/rustler_precompiled/issues/23