### PR TITLE
Fix the wrong type_spec

### DIFF
--- a/lib/qrusty.ex
+++ b/lib/qrusty.ex
@@ -78,11 +78,13 @@ defmodule Qrusty do
 
   @type data :: String.t()
   @type format :: :svg | :png | :jpg | :jpeg | :png64 | :jpg64 | :jpeg64
+  @type error_correction :: :l | :m | :q | :h
   @type opts ::
           [
             size: integer(),
             height: integer(),
-            width: integer()
+            width: integer(),
+            ec: error_correction()
           ]
           | []
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Qrusty.MixProject do
   use Mix.Project
 
-  @version "0.1.5"
+  @version "0.1.6"
   @source_url "https://github.com/nbw/qrusty"
 
   def project do


### PR DESCRIPTION
The Error Correction option is missing from the Type Spec. So when I used the Error Correction option, the Dialyzer encountered an error. So I solved this by adding Error Correction to Type Spec.